### PR TITLE
Add scaling for shapes and test it

### DIFF
--- a/lib/shape.ml
+++ b/lib/shape.ml
@@ -47,6 +47,12 @@ let ellipse ?x ?y rx ry =
   | Some x, Some y -> Ellipse {c = {x; y}; rx; ry}
   | _ -> Ellipse {c = { x = canvas_mid.x; y = canvas_mid.y}; rx; ry}
 
+let scale factor s =
+  match s with
+  | Circle circle' -> circle ~x:circle'.c.x ~y:circle'.c.y (circle'.radius*factor)
+  | Rectangle rectangle' -> rectangle ~x:rectangle'.c.x ~y:rectangle'.c.y (rectangle'.length*factor) (rectangle'.width*factor)
+  | Ellipse ellipse' -> ellipse ~x:ellipse'.c.x ~y:ellipse'.c.y (ellipse'.rx*factor) (ellipse'.ry*factor)
+
 let show shapes = List.iter render_shape shapes
 
 let init () =

--- a/lib/shape.ml
+++ b/lib/shape.ml
@@ -59,12 +59,13 @@ let translate dx dy shape =
   | Line line -> Line {a = {x = line.a.x + dx; y = line.a.y + dy}; b = {x = line.b.x + dx; y = line.b.y + dy}}
 
 let scale (factor:float) s =
-  let scaled_length len fact = int_of_float ((float_of_int len) *. sqrt(fact) +. 0.5) in
+  let round x = int_of_float(x +. 0.5) in
+  let scale_length len fact =  round ((float_of_int len) *. sqrt(fact)) in
   match s with
-  | Circle circle' -> circle ~x:circle'.c.x ~y:circle'.c.y (scaled_length circle'.radius factor)
-  | Rectangle rectangle' -> rectangle ~x:rectangle'.c.x ~y:rectangle'.c.y (scaled_length rectangle'.length factor) (scaled_length rectangle'.width factor)
-  | Ellipse ellipse' -> ellipse ~x:ellipse'.c.x ~y:ellipse'.c.y (scaled_length ellipse'.rx factor) (scaled_length ellipse'.ry factor)
-  | Line line' -> line ~x1:line'.a.x ~y1:line'.a.y (scaled_length line'.b.x factor) (scaled_length line'.b.y factor)
+  | Circle circle' -> circle ~x:circle'.c.x ~y:circle'.c.y (scale_length circle'.radius factor)
+  | Rectangle rectangle' -> rectangle ~x:rectangle'.c.x ~y:rectangle'.c.y (scale_length rectangle'.length factor) (scale_length rectangle'.width factor)
+  | Ellipse ellipse' -> ellipse ~x:ellipse'.c.x ~y:ellipse'.c.y (scale_length ellipse'.rx factor) (scale_length ellipse'.ry factor)
+  | Line _line' -> failwith "Not Implemented"
 
 let show shapes = List.iter render_shape shapes
 

--- a/lib/shape.ml
+++ b/lib/shape.ml
@@ -47,11 +47,12 @@ let ellipse ?x ?y rx ry =
   | Some x, Some y -> Ellipse {c = {x; y}; rx; ry}
   | _ -> Ellipse {c = { x = canvas_mid.x; y = canvas_mid.y}; rx; ry}
 
-let scale factor s =
+let scale (factor:float) s =
+  let scaled_length len fact = int_of_float ((float_of_int len) *. sqrt(fact) +. 0.5) in
   match s with
-  | Circle circle' -> circle ~x:circle'.c.x ~y:circle'.c.y (circle'.radius*factor)
-  | Rectangle rectangle' -> rectangle ~x:rectangle'.c.x ~y:rectangle'.c.y (rectangle'.length*factor) (rectangle'.width*factor)
-  | Ellipse ellipse' -> ellipse ~x:ellipse'.c.x ~y:ellipse'.c.y (ellipse'.rx*factor) (ellipse'.ry*factor)
+  | Circle circle' -> circle ~x:circle'.c.x ~y:circle'.c.y (scaled_length circle'.radius factor)
+  | Rectangle rectangle' -> rectangle ~x:rectangle'.c.x ~y:rectangle'.c.y (scaled_length rectangle'.length factor) (scaled_length rectangle'.width factor)
+  | Ellipse ellipse' -> ellipse ~x:ellipse'.c.x ~y:ellipse'.c.y (scaled_length ellipse'.rx factor) (scaled_length ellipse'.ry factor)
 
 let show shapes = List.iter render_shape shapes
 

--- a/lib/shape.ml
+++ b/lib/shape.ml
@@ -65,7 +65,7 @@ let translate dx dy shape =
   | Ellipse ellipse -> Ellipse { ellipse with c = { x = ellipse.c.x + dx; y = ellipse.c.y + dy } }
   | Line line -> Line {a = {x = line.a.x + dx; y = line.a.y + dy}; b = {x = line.b.x + dx; y = line.b.y + dy}}
 
-let scale (factor:float) s =
+let scale factor s =
   let round x = int_of_float(x +. 0.5) in
   let scale_length len fact =  round ((float_of_int len) *. sqrt(fact)) in
   match s with

--- a/lib/shape.mli
+++ b/lib/shape.mli
@@ -6,6 +6,7 @@ val circle : ?x:int -> ?y:int -> int -> shape
 val rectangle : ?x:int -> ?y:int -> int -> int -> shape
 val ellipse : ?x:int -> ?y:int -> int -> int -> shape
 val show : shape list -> unit
+val scale: int -> shape -> shape
 
 val draw_axes : bool -> unit
 val set_dimensions : int -> int -> unit

--- a/lib/shape.mli
+++ b/lib/shape.mli
@@ -6,7 +6,7 @@ val circle : ?x:int -> ?y:int -> int -> shape
 val rectangle : ?x:int -> ?y:int -> int -> int -> shape
 val ellipse : ?x:int -> ?y:int -> int -> int -> shape
 val show : shape list -> unit
-val scale: int -> shape -> shape
+val scale: float -> shape -> shape
 
 val draw_axes : bool -> unit
 val set_dimensions : int -> int -> unit

--- a/test/dune
+++ b/test/dune
@@ -2,3 +2,8 @@
  (name test_circle)
  (modules test_circle)
  (libraries joy graphics))
+
+(test
+ (name scale_shape)
+ (modules scale_shape)
+ (libraries joy graphics))

--- a/test/scale_shape.ml
+++ b/test/scale_shape.ml
@@ -4,14 +4,14 @@ let () =
   (* set_dimensions 100 100; *)
   init ();
   let c1 = circle 50 in
-  let c2 = scale 2 c1 in
-  let c3 = scale 3 c1 in
+  let c2 = scale 2. c1 in
+  let c3 = scale 3. c1 in
   let r1 = rectangle ~x:10 ~y:500 100 100 in
-  let r2 = scale 2 r1 in
-  let r3 = scale 3 r1 in
+  let r2 = scale 2. r1 in
+  let r3 = scale 3. r1 in
   let e1 = ellipse ~x:500 ~y:500 30 50 in
-  let e2 = scale 2 e1 in
-  let e3 = scale 3 e1 in
+  let e2 = scale 2. e1 in
+  let e3 = scale 3. e1 in
   show [ c1; c2; c3; r1; r2; r3; e1; e2; e3 ];
   close ();
   

--- a/test/scale_shape.ml
+++ b/test/scale_shape.ml
@@ -1,0 +1,17 @@
+open Joy.Shape
+
+let () =
+  (* set_dimensions 100 100; *)
+  init ();
+  let c1 = circle 50 in
+  let c2 = scale 2 c1 in
+  let c3 = scale 3 c1 in
+  let r1 = rectangle ~x:10 ~y:500 100 100 in
+  let r2 = scale 2 r1 in
+  let r3 = scale 3 r1 in
+  let e1 = ellipse ~x:500 ~y:500 30 50 in
+  let e2 = scale 2 e1 in
+  let e3 = scale 3 e1 in
+  show [ c1; c2; c3; r1; r2; r3; e1; e2; e3 ];
+  close ();
+  

--- a/test/test_all.ml
+++ b/test/test_all.ml
@@ -1,5 +1,5 @@
 let () =
   Test_circle.run ();
-  Test_scale_shape.run ();;
   Test_ellipse.run ();
   Test_rectangle.run ();
+  Test_scale_shape.run ();

--- a/test/test_scale_shape.ml
+++ b/test/test_scale_shape.ml
@@ -13,9 +13,5 @@ let run () =
   let e2 = scale 2. e1 in
   let e3 = scale 3. e1 in
   show [ c1; c2; c3; r1; r2; r3; e1; e2; e3 ];
-  let l1 = line  30 50 in
-  let l2 = scale 2. e1 in
-  (* let l3 = scale 3. e1 in *)
-  show [ c1; c2; c3; r1; r2; r3; e1; e2; e3; l1; l2];
   close ();
   

--- a/test/test_scale_shape.ml
+++ b/test/test_scale_shape.ml
@@ -1,17 +1,16 @@
 open Joy.Shape
 
 let run () =
-  (* set_dimensions 100 100; *)
   init ();
   let c1 = circle 50 in
   let c2 = scale 2. c1 in
-  let c3 = scale 3. c1 in
-  let r1 = rectangle ~x:10 ~y:500 100 100 in
+  let c3 = scale 0.5 c1 in
+  let r1 = rectangle 100 100 |> translate 10 500 in
   let r2 = scale 2. r1 in
-  let r3 = scale 3. r1 in
-  let e1 = ellipse ~x:500 ~y:500 30 50 in
+  let r3 = scale 0.02 r1 in
+  let e1 = ellipse 30 50 |> translate 500 500 in
   let e2 = scale 2. e1 in
-  let e3 = scale 3. e1 in
+  let e3 = scale 0.7 e1 in
   show [ c1; c2; c3; r1; r2; r3; e1; e2; e3 ];
   close ();
   


### PR DESCRIPTION
- This PR adds a scale feature to the shapes currently supported by Joy library. 
- For the rectangle, the lower left coordinates is fixed but we could change this to make the center fixed. 
- Addresses [this](https://github.com/Sudha247/ocaml-joy/issues/32) issue