### PR TITLE
Fix #27: Use simple executable instead of automated tests

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -1,4 +1,3 @@
-(test
- (name test_circle)
- (modules test_circle)
- (libraries joy graphics))
+(executable
+  (name test_all)
+  (libraries joy graphics))

--- a/test/dune
+++ b/test/dune
@@ -1,3 +1,3 @@
 (executable
-  (name test_all)
-  (libraries joy graphics))
+ (name test_all)
+ (libraries joy graphics))

--- a/test/test_all.ml
+++ b/test/test_all.ml
@@ -1,0 +1,2 @@
+let () =
+  Test_circle.run ()

--- a/test/test_circle.ml
+++ b/test/test_circle.ml
@@ -1,8 +1,8 @@
 open Joy.Shape
 
-let () =
+let run () =
   init ();
   let c1 = circle 50 in
   let c2 = circle 100 in
   show [ c1; c2 ];
-  close ();
+  close ()


### PR DESCRIPTION
Fix #27 by using a simple executable instead of dune tests.