### PR TITLE
refactored examples

### DIFF
--- a/examples/axes.ml
+++ b/examples/axes.ml
@@ -1,6 +1,6 @@
 open Joy.Shape 
 
-let _ = 
+let () = 
   draw_axes true;
   init ();
   let c = circle 50 in 

--- a/examples/circle.ml
+++ b/examples/circle.ml
@@ -1,12 +1,7 @@
-open Graphics
+open Joy.Shape
 
-let () =
-  open_graph " 300x300";
-  (* Open a graphics window with dimensions 800x600 *)
-  set_color black;
-
-  draw_circle 150 150 50;
-
-  ignore (read_line ());
-  close_graph ();
-  exit 0
+let _ =
+  init ();
+  let c = circle 75 in 
+  render_shape c;
+  close ()

--- a/examples/circle.ml
+++ b/examples/circle.ml
@@ -4,4 +4,5 @@ let _ =
   init ();
   let c = circle 75 in 
   render_shape c;
-  close ()
+  close ();
+  exit 0

--- a/examples/circle_graph.ml
+++ b/examples/circle_graph.ml
@@ -1,68 +1,9 @@
-(* open Graphics
-
-type point = { x : int; y : int }
-type rectangle = { c : point; length : int; width : int }
-type circle = { c : point; radius : int }
-type shape = Circle of circle | Rectangle of rectangle
-type _shapes = shape list
-
-let render_shape s =
-  match s with
-  | Circle circle -> draw_circle circle.c.x circle.c.y circle.radius
-  | Rectangle rectangle ->
-      draw_rect rectangle.c.x rectangle.c.y rectangle.length rectangle.width
-
-let circle ?x ?y r =
-  match (x, y) with
-  | Some x, Some y -> Circle { c = { x; y }; radius = r }
-  | _ -> Circle { c = { x = 450; y = 450 }; radius = r }
-
-let _rectangle ?x ?y length width =
-  match (x, y) with
-  | Some x, Some y -> Rectangle { c = { x; y }; length; width }
-  | _ -> Rectangle { c = { x = 150; y = 150 }; length; width }
-
-let show shapes = List.iter render_shape shapes *)
-
-
-open Graphics
-
-type point = { x : int; y : int }
-type circle = { c : point; radius : int }
-
-type shape = Circle of circle
-
-let canvas_mid = { x = 250; y = 250}
-
-let render_shape s =
-  match s with
-  | Circle circle -> Graphics.draw_circle circle.c.x circle.c.y circle.radius
-
-let circle ?x ?y r =
-  match (x, y) with
-  | Some x, Some y -> Circle { c = { x; y }; radius = r }
-  | _ -> Circle { c = { x = canvas_mid.x; y = canvas_mid.y }; radius = r }
-
-let show shapes = List.iter render_shape shapes
-
-(* let () =
-  open_graph " 500x500";
-  (* Open a graphics window with dimensions 800x600 *)
-  set_color black;
-
-  let c1 = circle 100 in
-  let c2 = circle 200 in
-  show [ c1; c2 ];
-
-  ignore (read_line ());
-  close_graph () *)
+open Joy.Shape
 
 let () =
-  Graphics.open_graph " 500x500";
-  set_color Graphics.black;
+  init ();
   let c1 = circle 50 in
   let c2 = circle 100 in
   show [ c1; c2 ];
-  ignore (read_line ());
-  (*wait for prompt from user before closing*)
-  Graphics.close_graph ()
+  close ();
+  exit 0

--- a/examples/circle_grid.ml
+++ b/examples/circle_grid.ml
@@ -1,26 +1,18 @@
 open Joy.Shape
 
-let grid_of_circles spacing =
-  let create_circle x y =
-    circle ~x:x ~y:y 50
-  in
-  let circles = ref [] in
-  let half_spacing = spacing / 2 in
-  let x_positions = [250 - half_spacing; 250 + half_spacing] in
-  let y_positions = [250 - half_spacing; 250 + half_spacing] in
-  for x = 0 to 1 do
-    for y = 0 to 1 do
-      let circle_x = List.nth x_positions x in
-      let circle_y = List.nth y_positions y in
-      circles := create_circle circle_x circle_y :: !circles
-    done
-  done;
-  !circles
+let spacing = 50
+let center = 250
+
+let grid_of_circles () = 
+  (* cartesian product - creates list of all combinations of the elements in two lists *)
+  let cartesian_product l l' = 
+    List.concat (List.map (fun e -> List.map (fun e' -> (e, e')) l') l) in
+  let coords = cartesian_product [-1; 1] [1; -1] in 
+  List.map (fun (x, y) -> circle ~x: (center + x * spacing) ~y: (center + y * spacing) 50) coords
 
 let () =
   init ();
-  let spacing = 100 in 
-  let circles = grid_of_circles spacing in
+  let circles = grid_of_circles () in
   show circles;
   close ();
   exit 0

--- a/examples/circle_grid.ml
+++ b/examples/circle_grid.ml
@@ -1,28 +1,13 @@
-open Graphics
+open Joy.Shape
 
-type point = { x : int; y : int }
-type circle = { c : point; radius : int }
-
-type shape = Circle of circle
-
-let canvas_size = (1000, 1000)
-let canvas_mid = { x = fst canvas_size / 2; y = snd canvas_size / 2 }
-
-let render_shape s =
-  match s with
-  | Circle circle -> draw_circle circle.c.x circle.c.y circle.radius
-
-let grid_of_circles ?x ?y spacing =
-  let center = match (x, y) with
-    | Some x, Some y -> { x; y }
-    | _ -> canvas_mid in
+let grid_of_circles spacing =
   let create_circle x y =
-    Circle { c = { x; y }; radius = 50 } 
+    circle ~x:x ~y:y 50
   in
   let circles = ref [] in
   let half_spacing = spacing / 2 in
-  let x_positions = [center.x - half_spacing; center.x + half_spacing] in
-  let y_positions = [center.y - half_spacing; center.y + half_spacing] in
+  let x_positions = [250 - half_spacing; 250 + half_spacing] in
+  let y_positions = [250 - half_spacing; 250 + half_spacing] in
   for x = 0 to 1 do
     for y = 0 to 1 do
       let circle_x = List.nth x_positions x in
@@ -32,15 +17,10 @@ let grid_of_circles ?x ?y spacing =
   done;
   !circles
 
-let show shapes = List.iter render_shape shapes
-
 let () =
-  open_graph (" " ^ string_of_int (fst canvas_size) ^ "x" ^ string_of_int (snd canvas_size));
-  set_color black;
-
+  init ();
   let spacing = 100 in 
   let circles = grid_of_circles spacing in
   show circles;
-
-  ignore (read_line ());
-  close_graph ()
+  close ();
+  exit 0

--- a/examples/circle_rectangle.ml
+++ b/examples/circle_rectangle.ml
@@ -6,5 +6,5 @@ let () =
   let circle = circle 50 in 
   let rectangle = rectangle ~x: 200 ~y: 200 100 100 in 
   show [circle; rectangle];
-
-  close ()
+  close ();
+  exit 0

--- a/examples/circle_rectangle.ml
+++ b/examples/circle_rectangle.ml
@@ -1,48 +1,10 @@
-open Graphics
-
-type point = { x : int; y : int }
-type circle = { c : point; radius : int }
-type rectangle = { c : point; length : int; width : int }
-
-type shape = Circle of circle | Rectangle of rectangle
-
-let canvas_size = (500, 500)
-let canvas_mid = { x = fst canvas_size / 2; y = snd canvas_size / 2 }
-
-let render_shape s =
-  match s with
-  | Circle circle -> draw_circle circle.c.x circle.c.y circle.radius
-  | Rectangle rect ->
-      let x1 = rect.c.x - (rect.length / 2) in
-      let x2 = rect.c.x + (rect.length / 2) in
-      let y1 = rect.c.y - (rect.width / 2) in
-      let y2 = rect.c.y + (rect.width / 2) in
-      draw_rect x1 y1 (x2 - x1) (y2 - y1)
-
-let circle radius =
-  let center = canvas_mid in
-  Circle { c = center; radius }
-
-let rectangle_outside_circle rectangle_length rectangle_width circle_radius =
-  let circle_center = canvas_mid in
-  let circle_cx = circle_center.x in
-  let circle_cy = circle_center.y in
-  let rectangle_cx = circle_cx in
-  let rectangle_cy = circle_cy in
-  let distance_x = circle_radius + (rectangle_length / 2) + 20 in
-  let distance_y = circle_radius + (rectangle_width / 2) + 20 in
-  Rectangle { c = { x = rectangle_cx; y = rectangle_cy }; length = distance_x; width = distance_y }
-
-let show shapes = List.iter render_shape shapes
+open Joy.Shape
 
 let () =
-  open_graph (" " ^ string_of_int (fst canvas_size) ^ "x" ^ string_of_int (snd canvas_size));
-  set_color black;
+  init ();
 
-  let circle_shape = circle 40 in 
-  let rectangle_shape = rectangle_outside_circle 120 80 60 in 
+  let circle = circle 50 in 
+  let rectangle = rectangle ~x: 200 ~y: 200 100 100 in 
+  show [circle; rectangle];
 
-  show [circle_shape; rectangle_shape];
-
-  ignore (read_line ());
-  close_graph ()
+  close ()

--- a/examples/circle_row.ml
+++ b/examples/circle_row.ml
@@ -1,42 +1,13 @@
-open Graphics
+open Joy.Shape
 
-type point = { x : int; y : int }
-type circle = { c : point; radius : int }
+let rec range a b = if a > b then [] else a :: range (a + 1) b
 
-type shape = Circle of circle
-
-let canvas_size = (1000, 1000)
-let canvas_mid = { x = fst canvas_size / 2; y = snd canvas_size / 2 }
-
-let render_shape s =
-  match s with
-  | Circle circle -> draw_circle circle.c.x circle.c.y circle.radius
-
-let row_of_circles ?x ?y spacing =
-  let center = match (x, y) with
-    | Some x, Some y -> { x; y }
-    | _ -> canvas_mid in
-  let create_circle x =
-    Circle { c = { x; y = center.y }; radius = 50 } 
-  in
-  let circles = ref [] in
-  let total_width = 3 * spacing in 
-  let start_x = center.x - total_width / 2 in 
-  for i = 0 to 2 do
-    let x = start_x + i * spacing in
-    circles := create_circle x :: !circles
-  done;
-  !circles
-
-let show shapes = List.iter render_shape shapes
-
-let () =
-  open_graph (" " ^ string_of_int (fst canvas_size) ^ "x" ^ string_of_int (snd canvas_size));
-  set_color black;
-
-  let spacing = 150 in 
-  let circles = row_of_circles spacing in
+let _ =
+  init ();
+  let center = 250 in
+  let radius = 50 in 
+  let idx_to_circle i = 
+    (circle ~x: (radius + center + (i - 2) * radius * 2) ~y: center radius) in
+  let circles = List.map idx_to_circle (range 0 3) in
   show circles;
-
-  ignore (read_line ());
-  close_graph ()
+  close ()

--- a/examples/circle_row.ml
+++ b/examples/circle_row.ml
@@ -10,4 +10,5 @@ let _ =
     (circle ~x: (radius + center + (i - 2) * radius * 2) ~y: center radius) in
   let circles = List.map idx_to_circle (range 0 3) in
   show circles;
-  close ()
+  close ();
+  exit 0

--- a/examples/concentric_circles.ml
+++ b/examples/concentric_circles.ml
@@ -7,4 +7,5 @@ let _ =
   let radius = 50 in
   let circles = List.map  (fun i -> circle (i * radius)) (range 1 4) in 
   show circles;
-  close ()
+  close ();
+  exit 0

--- a/examples/concentric_circles.ml
+++ b/examples/concentric_circles.ml
@@ -1,37 +1,10 @@
-open Graphics
+open Joy.Shape 
 
-type point = { x : int; y : int }
-type circle = { c : point; radius : int }
+let rec range a b = if a > b then [] else a :: range (a + 1) b
 
-type shape = Circle of circle
-
-let canvas_size = (500, 500)
-let canvas_mid = { x = fst canvas_size / 2; y = snd canvas_size / 2 }
-
-let render_shape s =
-  match s with
-  | Circle circle -> draw_circle circle.c.x circle.c.y circle.radius
-
-let concentric_circles ?x ?y num_circles spacing =
-  let center = match (x, y) with
-    | Some x, Some y -> { x; y }
-    | _ -> canvas_mid in
-  let rec create_circles n radius acc =
-    if n <= 0 then acc
-    else
-      let c = Circle { c = center; radius } in
-      create_circles (n - 1) (radius + spacing) (c :: acc)
-  in
-  create_circles num_circles 10 []
-
-let show shapes = List.iter render_shape shapes
-
-let () =
-  open_graph (" " ^ string_of_int (fst canvas_size) ^ "x" ^ string_of_int (snd canvas_size));
-  set_color black;
-
-  let circles = concentric_circles 5 20 in
+let _ = 
+  init ();
+  let radius = 50 in
+  let circles = List.map  (fun i -> circle (i * radius)) (range 1 4) in 
   show circles;
-
-  ignore (read_line ());
-  close_graph ()
+  close ()

--- a/examples/dune
+++ b/examples/dune
@@ -1,47 +1,47 @@
 (executable
  (name circle)
  (modules circle)
- (libraries graphics))
+ (libraries joy))
 
 (executable
  (name circle_graph)
  (modules circle_graph)
- (libraries graphics))
+ (libraries joy))
 
 (executable
  (name concentric_circles)
  (modules concentric_circles)
- (libraries graphics))
+ (libraries joy))
 
 (executable
  (name rectangle)
  (modules rectangle)
- (libraries graphics))
+ (libraries joy))
 
 (executable
  (name circle_grid)
  (modules circle_grid)
- (libraries graphics))
+ (libraries joy))
 
 (executable
  (name circle_row)
  (modules circle_row)
- (libraries graphics))
+ (libraries joy))
 
 (executable
  (name circle_rectangle)
  (modules circle_rectangle)
- (libraries graphics))
+ (libraries joy))
 
 (executable
  (name triangle)
  (modules triangle)
- (libraries graphics))
+ (libraries joy))
 
 (executable
  (name star)
  (modules star)
- (libraries graphics))
+ (libraries joy))
 
 (executable
  (name axes)
@@ -67,4 +67,3 @@
  (name line)
  (modules line)
  (libraries joy))
-

--- a/examples/line.ml
+++ b/examples/line.ml
@@ -8,6 +8,6 @@ let lines = List.map (fun i -> let newx = (i |> inc |> ( * ) line_interval) in (
 
 let _ = 
   init ();
-  List.iter render_shape lines;
+  show lines;
   close ();
   exit 0

--- a/examples/rectangle.ml
+++ b/examples/rectangle.ml
@@ -1,36 +1,8 @@
-open Graphics
+open Joy.Shape 
 
-type point = { x : int; y : int }
-type rectangle = { c : point; length : int; width : int }
-
-type shape = Rectangle of rectangle
-
-let canvas_size = (500, 500)
-let canvas_mid = { x = fst canvas_size / 2; y = snd canvas_size / 2 }
-
-let render_shape s =
-  match s with
-  | Rectangle rect ->
-      let x1 = rect.c.x - (rect.length / 2) in
-      let x2 = rect.c.x + (rect.length / 2) in
-      let y1 = rect.c.y - (rect.width / 2) in
-      let y2 = rect.c.y + (rect.width / 2) in
-      draw_rect x1 y1 (x2 - x1) (y2 - y1)
-
-let rectangle ?x ?y length width =
-  let center = match (x, y) with
-    | Some x, Some y -> { x; y }
-    | _ -> canvas_mid in
-  Rectangle { c = center; length; width }
-
-let show shapes = List.iter render_shape shapes
-
-let () =
-  open_graph (" " ^ string_of_int (fst canvas_size) ^ "x" ^ string_of_int (snd canvas_size));
-  set_color black;
-
-  let rect = rectangle 200 100 in
-  show [rect];
-
-  ignore (read_line ());
-  close_graph ()
+let _ = 
+  init ();
+  let rect = rectangle 100 100 in 
+  render_shape rect;
+  close ();
+  exit 0

--- a/examples/star.ml
+++ b/examples/star.ml
@@ -1,46 +1,31 @@
-open Graphics
+open Joy.Shape 
 
-type point = { x : int; y : int }
+let center = (250, 250)
+let num_points = 5
+let outer = 100
+let inner = 35
 
-type star = { center : point; outer_radius : int; inner_radius : int; num_points : int }
+let deg_to_rad angle = angle *. Float.pi /. 180.0
+let get_pos angle radius = 
+  let x = (fst center) + int_of_float (radius *. cos (deg_to_rad angle)) in 
+  let y = (snd center) + int_of_float (radius *. sin (deg_to_rad angle)) in 
+  (x, y)
 
-type shape = Star of star
+let draw_star () =
+  let step = 360.0 /. float_of_int num_points in
+  Graphics.moveto ((fst center) + outer) (snd center);
+  for i = 1 to num_points * 2 do 
+    let angle = float_of_int i *. step in 
+    let radius = float_of_int (if i mod 2 = 0 then outer else inner) in 
+    let (x, y) = get_pos angle radius in 
+    Graphics.lineto x y 
+  done; 
+  Graphics.lineto ((fst center) + outer) (snd center)
 
-let canvas_size = (500, 500)
 
-let render_shape s =
-  match s with
-  | Star star ->
-      let center_x = star.center.x in
-      let center_y = star.center.y in
-      let outer_r = float_of_int star.outer_radius in  
-      let inner_r = float_of_int star.inner_radius in  
-      let num_points = star.num_points in
-      let angle_step = 360.0 /. float_of_int num_points in
-      moveto (center_x + int_of_float outer_r) center_y;
-      for i = 1 to num_points * 2 do
-        let angle = float_of_int i *. angle_step in
-        let radius = if i mod 2 = 0 then outer_r else inner_r in
-        let x = center_x + int_of_float (radius *. cos (angle *. 3.14159265 /. 180.0)) in
-        let y = center_y + int_of_float (radius *. sin (angle *. 3.14159265 /. 180.0)) in
-        lineto x y
-      done;
-      lineto (center_x + int_of_float outer_r) center_y
 
-let star center outer_radius inner_radius num_points =
-  Star { center; outer_radius; inner_radius; num_points }
-
-let show shapes = List.iter render_shape shapes
-
-let () =
-  open_graph (" " ^ string_of_int (fst canvas_size) ^ "x" ^ string_of_int (snd canvas_size));
-  set_color black;
-
-  let star_shape = star { x = 250; y = 250 } 50 20 5 in
-
-  show [star_shape];
-
-  ignore (read_line ());
-  close_graph ()
-
-  
+let _ = 
+  init ();
+  draw_star ();
+  close ();
+  exit 0

--- a/examples/translate_circle.ml
+++ b/examples/translate_circle.ml
@@ -10,4 +10,5 @@ let () =
   (* Display both circles *)
   show [c1; c2];
 
-  close ()
+  close ();
+  exit 0

--- a/examples/translate_ellipse.ml
+++ b/examples/translate_ellipse.ml
@@ -10,4 +10,5 @@ let () =
   (* Display both ellipses *)
   show [e1; e2];
 
-  close ()
+  close ();
+  exit 0

--- a/examples/translate_rectangle.ml
+++ b/examples/translate_rectangle.ml
@@ -10,4 +10,5 @@ let () =
   (* Display rectangle transform *)
   show [r1; r2];
 
-  close ()
+  close ();
+  exit 0

--- a/examples/triangle.ml
+++ b/examples/triangle.ml
@@ -1,38 +1,15 @@
-open Graphics
+open Joy.Shape
 
-type point = { x : int; y : int }
-type triangle = { p1 : point; p2 : point; p3 : point }
+let draw_triangle () = 
+  let p1 = (250, 400) in 
+  let p2 = (150, 200) in 
+  let p3 = (350, 200) in 
+  let points = [(p1, p2); (p2, p3); (p3, p1)] in 
+  let lines = List.map (fun ((a, b), (c, d)) -> line ~x1: a ~y1: b c d) points in
+  show lines
 
-type shape = Triangle of triangle
-
-let canvas_size = (500, 500)
-
-let render_shape s =
-  match s with
-  | Triangle tri ->
-      let x1 = tri.p1.x in
-      let y1 = tri.p1.y in
-      let x2 = tri.p2.x in
-      let y2 = tri.p2.y in
-      let x3 = tri.p3.x in
-      let y3 = tri.p3.y in
-      moveto x1 y1;
-      lineto x2 y2;
-      lineto x3 y3;
-      lineto x1 y1
-
-let triangle p1 p2 p3 =
-  Triangle { p1; p2; p3 }
-
-let show shapes = List.iter render_shape shapes
-
-let () =
-  open_graph (" " ^ string_of_int (fst canvas_size) ^ "x" ^ string_of_int (snd canvas_size));
-  set_color black;
-
-  let triangle_shape = triangle { x = 250; y = 400 } { x = 150; y = 200 } { x = 350; y = 200 } in
-
-  show [triangle_shape];
-
-  ignore (read_line ());
-  close_graph ()
+let _ = 
+  init ();
+  draw_triangle ();
+  close ();
+  exit 0

--- a/lib/shape.ml
+++ b/lib/shape.ml
@@ -36,7 +36,6 @@ let circle ?x ?y r =
   | _ -> Circle { c = { x = canvas_mid.x; y = canvas_mid.y }; radius = r }
 
 let rectangle ?x ?y length width =
-  
   match (x, y) with
   | Some x, Some y -> Rectangle { c = { x; y }; length; width }
   | _ -> Rectangle { c = { x = canvas_mid.x; y = canvas_mid.y }; length; width }


### PR DESCRIPTION
Removed repetition in examples by requiring Joy.Shape as opposed to the Graphics module, refactored to increase readability and make more declarative.