### PR TITLE
Added `repeat` function from original Python library

### DIFF
--- a/ellipse.py
+++ b/ellipse.py
@@ -1,0 +1,28 @@
+import numpy as np
+from joy import *
+
+
+class Ellipse:
+    def __init__(self, center, radius_x, radius_y):
+        self.center = np.array(center)
+        self.radius_x = radius_x
+        self.radius_y = radius_y
+
+    def rotate(self, angle):
+        # Translate to origin
+        translated_center = np.array([0, 0])
+        translated_center[0] = self.center[0] - self.radius_x
+        translated_center[1] = self.center[1] - self.radius_y
+
+        # Rotate around the origin
+        rotated_center = self.rotate_point(translated_center, angle)
+
+        # Translate back to the original center
+        self.center[0] = rotated_center[0] + self.radius_x
+        self.center[1] = rotated_center[1] + self.radius_y
+
+    @staticmethod
+    def rotate_point(point, angle):
+        x_rot = point[0] * np.cos(angle) - point[1] * np.sin(angle)
+        y_rot = point[0] * np.sin(angle) + point[1] * np.cos(angle)
+        return np.array([x_rot, y_rot])

--- a/examples/dune
+++ b/examples/dune
@@ -107,3 +107,8 @@
  (name circle_packing)
  (modules circle_packing)
  (libraries joy))
+ 
+(executable 
+ (name repeat)
+ (modules repeat)
+ (libraries joy))

--- a/examples/dune
+++ b/examples/dune
@@ -99,6 +99,7 @@
  (libraries joy))
 
 (executable
+<<<<<<< HEAD
  (name polygon)
  (modules polygon)
  (libraries joy))
@@ -109,6 +110,8 @@
  (libraries joy))
  
 (executable 
+=======
+>>>>>>> 66df79e (formatting)
  (name repeat)
  (modules repeat)
  (libraries joy))

--- a/examples/higher_transforms.ml
+++ b/examples/higher_transforms.ml
@@ -2,19 +2,13 @@ open Joy.Shape
 
 (* Higher order transformations can be composed with `comp`,
    which applies its function args right-to-left.
-   This allows us to create complex series transformations,
-   that can be applied iteratively *)
+   This allows us to create complex series of transformations,
+   that can be applied iteratively with the repeat function *)
 let transform = compose (translate 10 10) (scale 0.9)
-let rec range a b = if a > b then [] else a :: range (a + 1) b
 
 let () =
   init ();
-  let initial = rectangle ~point:(point (-250) (-250)) 100 100 in
-  let match_list l =
-    match l with
-    | [] -> [ transform initial ]
-    | last :: _ -> transform last :: l
-  in
-  let shapes = List.fold_right (fun _ acc -> match_list acc) (range 0 32) [] in
-  show shapes;
+  let initial = rectangle ~point:{x = (-250); y = (-250)} 100 100 in
+  let shapes = repeat 32 transform initial in
+  render_shape shapes;
   close ()

--- a/examples/repeat.ml
+++ b/examples/repeat.ml
@@ -1,0 +1,16 @@
+open Joy.Shape 
+
+(* 
+   demonstration of the repeat function 
+   takes n, an operation, and an initial shape, and applies the operation 
+   iteratively to the initial shape n times
+   
+   adapted from the original Joy python library's examples 
+*)
+
+let () =
+  init ();
+  let circle = circle ~point:{x = (-100); y = 0} 50 in 
+  let shapes = repeat 10 (translate 10 0) circle in 
+  render_shape shapes;
+  close ();

--- a/examples/repeat.ml
+++ b/examples/repeat.ml
@@ -1,16 +1,21 @@
-open Joy.Shape 
+open Joy.Shape
 
-(* 
-   demonstration of the repeat function 
-   takes n, an operation, and an initial shape, and applies the operation 
-   iteratively to the initial shape n times
-   
-   adapted from the original Joy python library's examples 
+(*
+    demonstration of the repeat function
+    takes n, an operation, and an initial shape, and applies the operation
+    iteratively to the initial shape n times
+
+    adapted from the original Joy python library's examples
 *)
 
 let () =
   init ();
+<<<<<<< HEAD
   let circle = circle ~point:{x = (-100); y = 0} 50 in 
   let shapes = repeat 10 (translate 10 0) circle in 
+=======
+  let circle = circle ~x:(-100) ~y:0 50 in
+  let shapes = repeat 10 (translate 10 0) circle in
+>>>>>>> 66df79e (formatting)
   render_shape shapes;
-  close ();
+  close ()

--- a/lib/shape.ml
+++ b/lib/shape.ml
@@ -143,6 +143,16 @@ let rec rotate degrees shape =
 
 let compose f g x = g (f x)
 
+let rec range a b = if a >= b then [] else a :: range (a + 1) b  
+let repeat n op shape = 
+  let match_list l = 
+    match l with
+    | [] -> [ op shape ]
+    | last :: _ -> op last :: l
+  in
+  let shapes = List.fold_right (fun _ acc -> match_list acc) (range 0 n) [] in 
+  complex shapes
+
 let render_axes () =
   set_color (rgb 192 192 192);
   let half_x = size_x () / 2 in

--- a/lib/shape.ml
+++ b/lib/shape.ml
@@ -142,15 +142,13 @@ let rec rotate degrees shape =
   | Complex shapes -> Complex (List.map (rotate degrees) shapes)
 
 let compose f g x = g (f x)
+let rec range a b = if a >= b then [] else a :: range (a + 1) b
 
-let rec range a b = if a >= b then [] else a :: range (a + 1) b  
-let repeat n op shape = 
-  let match_list l = 
-    match l with
-    | [] -> [ op shape ]
-    | last :: _ -> op last :: l
+let repeat n op shape =
+  let match_list l =
+    match l with [] -> [ op shape ] | last :: _ -> op last :: l
   in
-  let shapes = List.fold_right (fun _ acc -> match_list acc) (range 0 n) [] in 
+  let shapes = List.fold_right (fun _ acc -> match_list acc) (range 0 n) [] in
   complex shapes
 
 let render_axes () =

--- a/lib/shape.mli
+++ b/lib/shape.mli
@@ -15,6 +15,7 @@ val show : shape list -> unit
 val scale : float -> shape -> shape
 val rotate : int -> shape -> shape
 val compose : ('a -> 'b) -> ('b -> 'c) -> 'a -> 'c
+val repeat : int -> (shape -> shape) -> shape -> shape
 val draw_axes : bool -> unit
 val set_dimensions : int -> int -> unit
 val init : unit -> unit


### PR DESCRIPTION
Since we now have higher-order transformations and complex shapes, I took the liberty of implementing the repeat function from the original Python Joy library. Additionally refactored relevant examples.