### PR TITLE
Add example with rectangular canvas (for testing)

### DIFF
--- a/examples/dune
+++ b/examples/dune
@@ -79,11 +79,16 @@
  (libraries joy))
 
 (executable
+ (name rectangle_canvas)
+ (modules rectangle_canvas)
+ (libraries joy))
+
+(executable
  (name star)
  (modules star)
  (libraries joy))
- 
-(executable 
+
+(executable
  (name repeat)
  (modules repeat)
  (libraries joy))

--- a/examples/rectangle_canvas.ml
+++ b/examples/rectangle_canvas.ml
@@ -1,0 +1,9 @@
+open Joy
+
+let () =
+  init ~size:(500., 300.) ();
+  background (1., 1., 1., 1.);
+  let c = circle 50. in
+  set_color (0., 0., 0.);
+  show [ c ];
+  write ~filename:"rectangular_canvas.png" ()


### PR DESCRIPTION
A circle in a rectangular canvas should not become an ellipse.
