### PR TITLE
Fixed scaling issues

### DIFF
--- a/examples/rectangle.ml
+++ b/examples/rectangle.ml
@@ -5,5 +5,5 @@ let () =
   background (255, 255, 255, 255);
   set_color (0, 0, 0);
   let r = rectangle 100 200 in
-  show [r];
+  show [ r ];
   write ~filename:"rectangle.png" ()

--- a/examples/square.ml
+++ b/examples/square.ml
@@ -5,6 +5,5 @@ let () =
   background (255, 255, 255, 255);
   let square = rectangle 100 100 in
   set_color (0, 0, 0);
-  show [square];
+  show [ square ];
   write ~filename:"square.png" ()
-

--- a/lib/context.ml
+++ b/lib/context.ml
@@ -7,8 +7,8 @@ type context = {
 }
 
 (* Renders context to PNG *)
-let write ctx filename = 
-  Cairo.PNG.write ctx.surface filename; 
+let write ctx filename =
+  Cairo.PNG.write ctx.surface filename;
   Cairo.Surface.finish ctx.surface
 
 let context = ref None

--- a/lib/context.ml
+++ b/lib/context.ml
@@ -50,7 +50,7 @@ let set_color color =
 (* sets background color *)
 let background color =
   match !context with
-  | Some { ctx; _ }->
+  | Some { ctx; _ } ->
       let r, g, b, alpha = tmap4 scale_color_channel color in
       Cairo.set_source_rgb ctx r g b;
       Cairo.paint ctx ~alpha;

--- a/lib/context.ml
+++ b/lib/context.ml
@@ -7,7 +7,10 @@ type context = {
 }
 
 (* Renders context to PNG *)
-let write ctx filename = Cairo.PNG.write ctx.surface filename
+let write ctx filename = 
+  Cairo.PNG.write ctx.surface filename; 
+  Cairo.Surface.finish ctx.surface
+
 let context = ref None
 
 exception Context of string
@@ -26,30 +29,33 @@ let init_context line_width (w, h) axes =
 
   let surface = Cairo.Image.create Cairo.Image.ARGB32 ~w ~h in
   let ctx = Cairo.create surface in
-  Cairo.scale ctx (float_of_int w) (float_of_int h);
   Cairo.set_line_width ctx line_width;
   context := Some { ctx; surface; size = (w, h); axes }
 
 let resolution () = match !context with Some ctx -> ctx.size | None -> fail ()
+let tmap f (a, b) = (f a, f b)
 let tmap3 f (a, b, c) = (f a, f b, f c)
 let tmap4 f (a, b, c, d) = (f a, f b, f c, f d)
 let ( >> ) f g x = g (f x)
 let scale_color_channel x = x /. 256.
+let scale_color_channel = float_of_int >> scale_color_channel
 
 let set_color color =
   match !context with
   | Some ctx ->
-      let r, g, b = tmap3 (float_of_int >> scale_color_channel) color in
-      Cairo.set_source_rgba ctx.ctx r g b 1.
+      let r, g, b = tmap3 scale_color_channel color in
+      Cairo.set_source_rgb ctx.ctx r g b
   | None -> fail ()
 
 (* sets background color *)
 let background color =
   match !context with
-  | Some ctx ->
-      let r, g, b, a = tmap4 (float_of_int >> scale_color_channel) color in
-      Cairo.set_source_rgba ctx.ctx r g b a;
-      Cairo.paint ctx.ctx
+  | Some ({ ctx; _ } as context) ->
+      let r, g, b, a = tmap4 scale_color_channel color in
+      let w, h = tmap float_of_int context.size in
+      Cairo.set_source_rgba ctx r g b a;
+      Cairo.rectangle ctx 0. 0. ~w ~h;
+      Cairo.fill ctx
   | None -> fail ()
 
 (** Sets the width of lines for both stroke of shapes and line primitives. 
@@ -57,7 +63,7 @@ let background color =
     default is 2 *)
 let set_line_width line_width =
   match !context with
-  | Some ctx -> Cairo.set_line_width ctx.ctx (float_of_int line_width /. 1000.)
+  | Some ctx -> Cairo.set_line_width ctx.ctx (float_of_int line_width)
   | None -> fail ()
 
 let save () =

--- a/lib/context.ml
+++ b/lib/context.ml
@@ -30,10 +30,10 @@ let init_context line_width (w, h) axes =
   let surface = Cairo.Image.create Cairo.Image.ARGB32 ~w ~h in
   let ctx = Cairo.create surface in
   Cairo.set_line_width ctx line_width;
+  Cairo.translate ctx (w / 2 |> float_of_int) (h / 2 |> float_of_int);
   context := Some { ctx; surface; size = (w, h); axes }
 
 let resolution () = match !context with Some ctx -> ctx.size | None -> fail ()
-let tmap f (a, b) = (f a, f b)
 let tmap3 f (a, b, c) = (f a, f b, f c)
 let tmap4 f (a, b, c, d) = (f a, f b, f c, f d)
 let ( >> ) f g x = g (f x)
@@ -50,11 +50,10 @@ let set_color color =
 (* sets background color *)
 let background color =
   match !context with
-  | Some ({ ctx; _ } as context) ->
-      let r, g, b, a = tmap4 scale_color_channel color in
-      let w, h = tmap float_of_int context.size in
-      Cairo.set_source_rgba ctx r g b a;
-      Cairo.rectangle ctx 0. 0. ~w ~h;
+  | Some { ctx; _ }->
+      let r, g, b, alpha = tmap4 scale_color_channel color in
+      Cairo.set_source_rgb ctx r g b;
+      Cairo.paint ctx ~alpha;
       Cairo.fill ctx
   | None -> fail ()
 

--- a/lib/joy.ml
+++ b/lib/joy.ml
@@ -23,7 +23,7 @@ let background = Context.background
 let set_line_width = Context.set_line_width
 
 let init ?(line_width = 2) ?(size = (800, 800)) ?(axes = false) () =
-  Context.init_context (float_of_int line_width /. 1000.) size axes
+  Context.init_context (float_of_int line_width) size axes
 
 let write ?(filename = "joy.png") () =
   match !Context.context with

--- a/lib/joy.ml
+++ b/lib/joy.ml
@@ -3,7 +3,6 @@ let context = Context.context
 type 'a point = 'a Shape.point
 type shape = Shape.shape
 type shapes = Shape.shapes
-
 type transformation = Transform.transformation
 
 let point = Shape.point

--- a/lib/joy.mli
+++ b/lib/joy.mli
@@ -1,7 +1,6 @@
 type 'a point = 'a Shape.point
 type shape = Shape.shape
 type shapes = Shape.shapes
-
 type transformation = Transform.transformation
 
 val point : int -> int -> float point

--- a/lib/render.ml
+++ b/lib/render.ml
@@ -6,7 +6,7 @@ let tmap f (x, y) = (f x, f y)
 let denormalize point =
   let x, y = Context.resolution () |> tmap float_of_int in
   let canvas_mid = { x; y } /! 2. in
-  ((point.x +. canvas_mid.x), (point.y +. canvas_mid.y))
+  (point.x +. canvas_mid.x, point.y +. canvas_mid.y)
 
 let draw_circle ctx ({ c; radius } : circle) =
   let x, y = denormalize c in

--- a/lib/render.ml
+++ b/lib/render.ml
@@ -4,12 +4,12 @@ open Context
 let tmap f (x, y) = (f x, f y)
 
 let draw_circle ctx ({ c; radius } : circle) =
-  let {x; y }= c in
+  let { x; y } = c in
   Cairo.arc ctx.ctx x y ~r:radius ~a1:0. ~a2:(Float.pi *. 2.);
   Cairo.stroke ctx.ctx
 
 let create_control_points { c; rx; ry } =
-  let {x; y }= c in
+  let { x; y } = c in
   let half_height = ry /. 2. in
   let width_two_thirds = rx *. (2. /. 3.) *. 2. in
   ( { x; y = y -. half_height },
@@ -36,8 +36,8 @@ let draw_ellipse ctx ellipse =
   Cairo.stroke ctx.ctx
 
 let draw_line ctx line =
-  let {x = x1; y = y1} = line.a in
-  let { x = x2; y = y2} = line.b in
+  let { x = x1; y = y1 } = line.a in
+  let { x = x2; y = y2 } = line.b in
   Cairo.move_to ctx.ctx x1 y1;
   Cairo.line_to ctx.ctx x2 y2;
   Cairo.stroke ctx.ctx
@@ -67,7 +67,9 @@ let draw_polygon ctx polygon =
   let points = partition 2 ~step:1 (polygon @ [ List.hd polygon ]) in
   List.iter
     (fun pair ->
-      let {x = x1; y = y1}, {x = x2; y = y2 } = (List.nth pair 0, List.nth pair 1) in
+      let { x = x1; y = y1 }, { x = x2; y = y2 } =
+        (List.nth pair 0, List.nth pair 1)
+      in
       Cairo.move_to ctx.ctx x1 y1;
       Cairo.line_to ctx.ctx x2 y2)
     points;
@@ -90,11 +92,9 @@ let show shapes =
   | None -> fail ()
 
 let render_axes () =
-  save ();
   let x, y = Context.resolution () |> tmap float_of_int in
   let half_x, half_y = (x /. 2., y /. 2.) in
   let x_axis = line ~a:{ x = 0.; y = -.half_y } { x = 0.; y = half_y } in
   let y_axis = line ~a:{ x = -.half_x; y = 0. } { x = half_x; y = 0. } in
   set_color (0, 0, 0);
-  show [ x_axis; y_axis ];
-  restore ()
+  show [ x_axis; y_axis ]

--- a/lib/render.ml
+++ b/lib/render.ml
@@ -3,18 +3,13 @@ open Context
 
 let tmap f (x, y) = (f x, f y)
 
-let denormalize point =
-  let x, y = Context.resolution () |> tmap float_of_int in
-  let canvas_mid = { x; y } /! 2. in
-  (point.x +. canvas_mid.x, point.y +. canvas_mid.y)
-
 let draw_circle ctx ({ c; radius } : circle) =
-  let x, y = denormalize c in
+  let {x; y }= c in
   Cairo.arc ctx.ctx x y ~r:radius ~a1:0. ~a2:(Float.pi *. 2.);
   Cairo.stroke ctx.ctx
 
 let create_control_points { c; rx; ry } =
-  let x, y = denormalize c in
+  let {x; y }= c in
   let half_height = ry /. 2. in
   let width_two_thirds = rx *. (2. /. 3.) *. 2. in
   ( { x; y = y -. half_height },
@@ -41,8 +36,8 @@ let draw_ellipse ctx ellipse =
   Cairo.stroke ctx.ctx
 
 let draw_line ctx line =
-  let x1, y1 = denormalize line.a in
-  let x2, y2 = denormalize line.b in
+  let {x = x1; y = y1} = line.a in
+  let { x = x2; y = y2} = line.b in
   Cairo.move_to ctx.ctx x1 y1;
   Cairo.line_to ctx.ctx x2 y2;
   Cairo.stroke ctx.ctx
@@ -72,8 +67,7 @@ let draw_polygon ctx polygon =
   let points = partition 2 ~step:1 (polygon @ [ List.hd polygon ]) in
   List.iter
     (fun pair ->
-      let pair = List.map denormalize pair in
-      let (x1, y1), (x2, y2) = (List.nth pair 0, List.nth pair 1) in
+      let {x = x1; y = y1}, {x = x2; y = y2 } = (List.nth pair 0, List.nth pair 1) in
       Cairo.move_to ctx.ctx x1 y1;
       Cairo.line_to ctx.ctx x2 y2)
     points;

--- a/lib/render.ml
+++ b/lib/render.ml
@@ -6,22 +6,17 @@ let tmap f (x, y) = (f x, f y)
 let denormalize point =
   let x, y = Context.resolution () |> tmap float_of_int in
   let canvas_mid = { x; y } /! 2. in
-  ((point.x +. canvas_mid.x) /. x, (point.y +. canvas_mid.y) /. y)
-
-let euclid_norm (x, y) = sqrt (Float.pow x 2. +. Float.pow y 2.) /. 2.
+  ((point.x +. canvas_mid.x), (point.y +. canvas_mid.y))
 
 let draw_circle ctx ({ c; radius } : circle) =
-  let size = tmap float_of_int ctx.size in
   let x, y = denormalize c in
-  let radius = radius /. euclid_norm size in
   Cairo.arc ctx.ctx x y ~r:radius ~a1:0. ~a2:(Float.pi *. 2.);
   Cairo.stroke ctx.ctx
 
 let create_control_points { c; rx; ry } =
-  let size = resolution () |> tmap float_of_int in
   let x, y = denormalize c in
-  let half_height = ry /. snd size in
-  let width_two_thirds = rx /. fst size *. (2. /. 3.) *. 2. in
+  let half_height = ry /. 2. in
+  let width_two_thirds = rx *. (2. /. 3.) *. 2. in
   ( { x; y = y -. half_height },
     ( x +. width_two_thirds,
       y -. half_height,
@@ -38,23 +33,19 @@ let create_control_points { c; rx; ry } =
 
 let draw_ellipse ctx ellipse =
   let start, curve_one, curve_two = create_control_points ellipse in
-  Cairo.save ctx.ctx;
   Cairo.move_to ctx.ctx start.x start.y;
   let x1, y1, x2, y2, x3, y3 = curve_one in
   Cairo.curve_to ctx.ctx x1 y1 x2 y2 x3 y3;
   let x1, y1, x2, y2, x3, y3 = curve_two in
   Cairo.curve_to ctx.ctx x1 y1 x2 y2 x3 y3;
-  Cairo.stroke ctx.ctx;
-  Cairo.restore ctx.ctx
+  Cairo.stroke ctx.ctx
 
 let draw_line ctx line =
-  save ();
   let x1, y1 = denormalize line.a in
   let x2, y2 = denormalize line.b in
   Cairo.move_to ctx.ctx x1 y1;
   Cairo.line_to ctx.ctx x2 y2;
-  Cairo.stroke ctx.ctx;
-  restore ()
+  Cairo.stroke ctx.ctx
 
 let rec take n lst =
   match (n, lst) with
@@ -86,7 +77,6 @@ let draw_polygon ctx polygon =
       Cairo.move_to ctx.ctx x1 y1;
       Cairo.line_to ctx.ctx x2 y2)
     points;
-  Cairo.move_to ctx.ctx 0. 0.;
   Cairo.stroke ctx.ctx
 
 let rec render_shape ctx = function
@@ -106,7 +96,6 @@ let show shapes =
   | None -> fail ()
 
 let render_axes () =
-  print_endline "rendering axes!";
   save ();
   let x, y = Context.resolution () |> tmap float_of_int in
   let half_x, half_y = (x /. 2., y /. 2.) in

--- a/lib/shape.ml
+++ b/lib/shape.ml
@@ -32,7 +32,7 @@ let circle ?(c = center) r = Circle { c; radius = float_of_int r }
 let rectangle ?(c = center) width height =
   let w, h = (float_of_int width, float_of_int height) in
   let x1 = c.x -. (w /. 2.) in
-  let y1 = c.x -. (h /. 2.) in
+  let y1 = c.y -. (h /. 2.) in
   Polygon
     [
       { x = x1; y = y1 };

--- a/lib/transform.ml
+++ b/lib/transform.ml
@@ -1,6 +1,6 @@
 open Shape
 
-type transformation = (shape -> shape)
+type transformation = shape -> shape
 
 let rec translate dx dy shape =
   match shape with

--- a/lib/transform.mli
+++ b/lib/transform.mli
@@ -1,4 +1,4 @@
-type transformation = (Shape.shape -> Shape.shape)
+type transformation = Shape.shape -> Shape.shape
 
 val translate : int -> int -> transformation
 val scale : float -> transformation


### PR DESCRIPTION
Refactored the Cairo backend to fix scaling+aspect ratio issues. Set up so that rendering to SVG files should be very easy, as well. This fixes both the `rectangular_canvas` and `circle_packing` demos.