### PR TITLE
Line rotation

### DIFF
--- a/lib/transform.ml
+++ b/lib/transform.ml
@@ -68,7 +68,7 @@ let rec rotate degrees shape =
   | Circle circle' -> Circle { circle' with c = rotate_point degrees circle'.c }
   | Ellipse ellipse' ->
       Ellipse { ellipse' with c = rotate_point degrees ellipse'.c }
-  | Line _line -> failwith "Not Implemented"
+  | Line line' -> { line' with b = rotate_point degrees line'.b } 
   | Polygon polygon' -> polygon (List.map (rotate_point degrees) polygon')
   | Complex shapes -> Complex (List.map (rotate degrees) shapes)
 

--- a/lib/transform.ml
+++ b/lib/transform.ml
@@ -68,7 +68,7 @@ let rec rotate degrees shape =
   | Circle circle' -> Circle { circle' with c = rotate_point degrees circle'.c }
   | Ellipse ellipse' ->
       Ellipse { ellipse' with c = rotate_point degrees ellipse'.c }
-  | Line line' -> { line' with b = rotate_point degrees line'.b } 
+  | Line line' -> Line { line' with b = rotate_point degrees line'.b } 
   | Polygon polygon' -> polygon (List.map (rotate_point degrees) polygon')
   | Complex shapes -> Complex (List.map (rotate degrees) shapes)
 


### PR DESCRIPTION
I was reading the Python Joy documentation and realized they have line rotation and we are still failing if a line is passed to `rotate`. So I added functionality that (I think) mirrors Python Joy, with the `b` point being rotated. 