### PR TITLE
adding no_stroke, no_fill

### DIFF
--- a/lib/joy.ml
+++ b/lib/joy.ml
@@ -25,6 +25,8 @@ let line = Shape.line
 let complex = Shape.complex
 let with_stroke = Shape.with_stroke
 let with_fill = Shape.with_fill
+let no_stroke = Shape.no_stroke
+let no_fill = Shape.no_fill
 let rotate = Transform.rotate
 let scale = Transform.scale
 let translate = Transform.translate
@@ -37,7 +39,7 @@ let set_line_width = Context.set_line_width
 let init ?(background = Color.white) ?(line_width = 2) ?(size = (500, 500))
     ?(axes = false) () =
   Context.init_context (Color.opaque background)
-    (float_of_int line_width /. 1000.)
+    (float_of_int line_width)
     size axes
 
 let write ?(filename = "joy.png") () =

--- a/lib/joy.mli
+++ b/lib/joy.mli
@@ -13,6 +13,8 @@ val polygon : float point list -> shape
 val complex : shapes -> shape
 val with_stroke : color -> shape -> shape
 val with_fill : color -> shape -> shape
+val no_stroke : shape -> shape 
+val no_fill : shape -> shape
 val rotate : int -> transformation
 val translate : int -> int -> transformation
 val scale : float -> transformation

--- a/lib/shape.ml
+++ b/lib/shape.ml
@@ -89,3 +89,21 @@ let rec with_fill fill = function
   | _ as line' ->
       print_endline "lines do not have a fill field!";
       line'
+
+let rec no_stroke = function 
+    | Circle circle' -> Circle { circle' with stroke = None }
+    | Ellipse ellipse' -> Ellipse { ellipse' with stroke = None }
+    | Polygon polygon' -> Polygon { polygon' with stroke = None }
+    | Complex complex' -> Complex (List.map no_stroke complex')
+    | _ as line' -> 
+      print_endline "Cannot remove stroke from lines";
+      line'
+
+let rec no_fill = function 
+      | Circle circle' -> Circle { circle' with fill = None }
+      | Ellipse ellipse' -> Ellipse { ellipse' with fill = None }
+      | Polygon polygon' -> Polygon { polygon' with fill = None }
+      | Complex complex' -> Complex (List.map no_fill complex')
+      | _ as line' -> 
+        print_endline "Lines do not have a fill field!";
+        line'

--- a/lib/shape.mli
+++ b/lib/shape.mli
@@ -47,3 +47,5 @@ val line : ?a:float point -> float point -> shape
 val polygon : float point list -> shape
 val with_stroke : color -> shape -> shape
 val with_fill : color -> shape -> shape
+val no_stroke : shape -> shape
+val no_fill : shape -> shape


### PR DESCRIPTION
I was working on refactoring the circle packing example the other day and realized there was no way to remove the stroke or fill of a shape, this fixes that.