### PR TITLE
remove 'render' in favor of 'show'

### DIFF
--- a/examples/axes.ml
+++ b/examples/axes.ml
@@ -6,6 +6,6 @@ let _ =
   init ~axes:true ();
   (* set background to opaque white *)
   let c = circle 50 in
-  render c;
+  show [ c ];
   (* Write to PNG! *)
   write ~filename:"axes.png" ()

--- a/examples/circle.ml
+++ b/examples/circle.ml
@@ -3,5 +3,5 @@ open Joy
 let () =
   init ();
   let c = circle 50 in
-  render c;
+  show [ c ];
   write ~filename:"circle.png" ()

--- a/examples/circle_packing.ml
+++ b/examples/circle_packing.ml
@@ -94,9 +94,7 @@ let () =
   let circles =
     List.map
       (fun ((x, y), radius) ->
-        circle
-          ~c:{x; y}
-          (int_of_float radius)
+        circle ~c:{ x; y } (int_of_float radius)
         |> with_stroke (rand_nth palette))
       concentric
   in

--- a/examples/color.ml
+++ b/examples/color.ml
@@ -3,5 +3,5 @@ open Joy
 let _ =
   init ();
   let c = circle 50 |> with_stroke red in
-  render c;
+  show [ c ];
   write ~filename:"color.png" ()

--- a/examples/concentric_circles.ml
+++ b/examples/concentric_circles.ml
@@ -12,5 +12,5 @@ let () =
     | _, _ -> arr
   in
   let circles = complex (make_concentric [] 21) in
-  render circles;
+  show [ circles ];
   write ~filename:"concentric_circles.png" ()

--- a/examples/ellipse.ml
+++ b/examples/ellipse.ml
@@ -5,5 +5,5 @@ let () =
   (* create an ellipse *)
   let e = ellipse 100 75 in
   (* render it *)
-  render e;
+  show [ e ];
   write ~filename:"ellipse.png" ()

--- a/examples/higher_transforms.ml
+++ b/examples/higher_transforms.ml
@@ -10,5 +10,5 @@ let () =
   init ();
   let initial = rectangle ~c:(point (-250) (-250)) 100 100 in
   let shapes = repeat 32 transform initial in
-  render shapes;
+  show [ shapes ];
   write ~filename:"higher_transforms.png" ()

--- a/examples/polygon.ml
+++ b/examples/polygon.ml
@@ -8,5 +8,5 @@ let () =
     polygon
       [ { x = -.size; y = 0. }; { x = 0.; y = size }; { x = size; y = 0. } ]
   in
-  render poly;
+  show [ poly ];
   write ~filename:"polygon.png" ()

--- a/examples/repeat.ml
+++ b/examples/repeat.ml
@@ -12,5 +12,5 @@ let () =
   init ();
   let circle = circle ~c:(point (-100) 0) 50 in
   let shapes = repeat 10 (translate 10 0) circle in
-  render shapes;
+  show [ shapes ];
   write ~filename:"repeat.png" ()

--- a/examples/star.ml
+++ b/examples/star.ml
@@ -18,5 +18,5 @@ let () =
   init ();
   set_line_width 3;
   let star = List.init points star_section |> List.flatten |> polygon in
-  render star;
+  show [ star ];
   write ~filename:"star.png" ()

--- a/examples/triangle.ml
+++ b/examples/triangle.ml
@@ -8,5 +8,5 @@ let () =
     polygon
       [ { x = -.size; y = 0. }; { x = 0.; y = size }; { x = size; y = 0. } ]
   in
-  render triangle;
+  show [ triangle ];
   write ~filename:"triangle.png" ()

--- a/lib/joy.ml
+++ b/lib/joy.ml
@@ -36,9 +36,8 @@ let set_line_width = Context.set_line_width
 
 let init ?(background = Color.white) ?(line_width = 2) ?(size = (500, 500))
     ?(axes = false) () =
-  Context.init_context (Color.opaque background)
-    (float_of_int line_width)
-    size axes
+  Context.init_context (Color.opaque background) (float_of_int line_width) size
+    axes
 
 let write ?(filename = "joy.png") () =
   match !Context.context with
@@ -47,5 +46,4 @@ let write ?(filename = "joy.png") () =
       Context.write ctx filename
   | None -> Context.fail ()
 
-let render shape = Render.render shape
 let show shapes = Render.show shapes

--- a/lib/joy.mli
+++ b/lib/joy.mli
@@ -39,6 +39,5 @@ val init :
   unit ->
   unit
 
-val render : shape -> unit
 val show : shapes -> unit
 val write : ?filename:string -> unit -> unit

--- a/lib/render.ml
+++ b/lib/render.ml
@@ -17,7 +17,7 @@ let draw_circle ctx ({ c; radius; stroke; fill } : circle) =
   Option.iter fill_circle fill;
   Cairo.Path.clear ctx.ctx
 
-let create_control_points ({x; y}, rx, ry) =
+let create_control_points ({ x; y }, rx, ry) =
   let half_height = ry /. 2. in
   let width_two_thirds = rx *. (2. /. 3.) *. 2. in
   ( { x; y = y -. half_height },
@@ -74,10 +74,7 @@ let rec partition n ?(step = 0) lst =
   | [] -> []
   | _ ->
       let taken, _ = take n lst in
-      if List.length taken = n then
-        taken
-        ::
-        partition n ~step (List.tl lst)
+      if List.length taken = n then taken :: partition n ~step (List.tl lst)
       else []
 
 let draw_polygon ctx { vertices = points; stroke; fill } =
@@ -102,20 +99,17 @@ let draw_polygon ctx { vertices = points; stroke; fill } =
   Option.iter fill_rect fill;
   Cairo.Path.clear ctx.ctx
 
-let rec render_shape ctx = function
-  | Circle circle -> draw_circle ctx circle
-  | Ellipse ellipse -> draw_ellipse ctx ellipse
-  | Line line -> draw_line ctx line
-  | Polygon polygon -> draw_polygon ctx polygon
-  | Complex complex -> List.iter (render_shape ctx) complex
-
 (* Validates context before rendering *)
-let render shape =
-  match !context with Some ctx -> render_shape ctx shape | None -> fail ()
-
 let show shapes =
+  let rec render ctx = function
+    | Circle circle -> draw_circle ctx circle
+    | Ellipse ellipse -> draw_ellipse ctx ellipse
+    | Line line -> draw_line ctx line
+    | Polygon polygon -> draw_polygon ctx polygon
+    | Complex complex -> List.iter (render ctx) complex
+  in
   match !context with
-  | Some ctx -> List.iter (render_shape ctx) shapes
+  | Some ctx -> List.iter (render ctx) shapes
   | None -> fail ()
 
 let render_axes () =

--- a/lib/render.mli
+++ b/lib/render.mli
@@ -3,6 +3,4 @@ val draw_ellipse : Context.context -> Shape.ellipse -> unit
 val draw_line : Context.context -> Shape.line -> unit
 val draw_polygon : Context.context -> Shape.polygon -> unit
 val render_axes : unit -> unit
-val render_shape : Context.context -> Shape.shape -> unit
-val render : Shape.shape -> unit
 val show : Shape.shape list -> unit


### PR DESCRIPTION
Removed `render` from all examples, as well of the library itself.