### PR TITLE
Optimize polygon rendering & fix polygon fill

### DIFF
--- a/examples/dune
+++ b/examples/dune
@@ -117,3 +117,8 @@
  (name color)
  (modules color)
  (libraries joy))
+
+(executable 
+ (name fill_rect)
+ (modules fill_rect)
+ (libraries joy))

--- a/examples/fill_rect.ml
+++ b/examples/fill_rect.ml
@@ -2,6 +2,6 @@ open Joy
 
 let () =
   init ();
-  let r = rectangle 500 500 |> no_stroke |> with_fill (255, 0, 0) in
+  let r = rectangle 200 200 |> with_fill (255, 0, 0) in
   show [ r ];
   write ~filename:"fill-rect.png" ()

--- a/examples/fill_rect.ml
+++ b/examples/fill_rect.ml
@@ -1,0 +1,7 @@
+open Joy
+
+let () =
+  init ();
+  let r = rectangle 500 500 |> no_stroke |> with_fill (255, 0, 0) in
+  show [ r ];
+  write ~filename:"fill-rect.png" ()

--- a/lib/render.ml
+++ b/lib/render.ml
@@ -71,15 +71,10 @@ let draw_polygon ctx { vertices; stroke; fill } =
     set_color fill;
     Cairo.fill_preserve ctx.ctx
   in
-  let points = partition 2 ~step:1 (vertices @ [ List.hd vertices ]) in
-  List.iter
-    (fun pair ->
-      let { x = x1; y = y1 }, { x = x2; y = y2 } =
-        (List.nth pair 0, List.nth pair 1)
-      in
-      Cairo.move_to ctx.ctx x1 (Float.neg y1);
-      Cairo.line_to ctx.ctx x2 (Float.neg y2))
-    points;
+  let { x; y }, t = (List.hd vertices, List.tl vertices) in 
+  Cairo.move_to ctx.ctx x y;
+  List.iter (fun { x = x'; y = y' } -> Cairo.line_to ctx.ctx x' y') t; 
+  Cairo.Path.close ctx.ctx;
   Option.iter stroke_rect stroke;
   Option.iter fill_rect fill;
   Cairo.Path.clear ctx.ctx


### PR DESCRIPTION
I noticed polygon fill didn't work and was digging through Cairo documentation and realized it was also sort of inefficient, so I fixed both of those and made a `fill_rect` example.