### PR TITLE
Add a dependency on the base library

### DIFF
--- a/joy.opam
+++ b/joy.opam
@@ -12,6 +12,7 @@ depends: [
   "dune" {>= "3.10"}
   "graphics"
   "cairo2"
+  "base"
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
CI seems to be failing because of a missing dependency on `base`. 