### PR TITLE
 Fix ellipse rotation to work correctly

### DIFF
--- a/examples/dune
+++ b/examples/dune
@@ -49,6 +49,11 @@
  (libraries joy))
 
 (executable
+ (name rotate_ellipse)
+ (modules rotate_ellipse)
+ (libraries joy))
+
+(executable
  (name line)
  (modules line)
  (libraries joy))
@@ -127,4 +132,3 @@
  (name smile)
  (modules smile)
  (libraries joy))
- 

--- a/examples/rotate_ellipse.ml
+++ b/examples/rotate_ellipse.ml
@@ -1,0 +1,15 @@
+open Joy
+
+let max = 32.
+let rec range a b = if a > b then [] else a :: range (a +. 1.) b
+
+let _ =
+  init ();
+  let rect = rectangle 100 50 |> translate 195 220 in
+  let ell = ellipse 100 50 |> translate 60 60 in
+  let nums = range 0. max in
+  let rotated =
+    List.map (fun i -> rotate (int_of_float (i /. max *. 360.0)) ell) nums
+  in
+  show (rect :: rotated);
+  write ~filename:"rotate_ellipse.png" ()

--- a/lib/render.ml
+++ b/lib/render.ml
@@ -16,7 +16,7 @@ let draw_circle ctx ({ c; radius; stroke; fill } : circle) =
   Option.iter fill_circle fill;
   Cairo.Path.clear ctx.ctx
 
-let draw_ellipse ctx { c; rx; ry; stroke; fill } =
+let draw_ellipse ctx { c; rx; ry; stroke; fill; rotation } =
   let stroke_ellipse stroke =
     set_color stroke;
     Cairo.stroke_preserve ctx.ctx
@@ -31,6 +31,7 @@ let draw_ellipse ctx { c; rx; ry; stroke; fill } =
 
   (* Translate and scale to create an ellipse from a circle *)
   Cairo.translate ctx.ctx c.x (Float.neg c.y);
+  Cairo.rotate ctx.ctx rotation;
   Cairo.scale ctx.ctx rx ry;
   Cairo.arc ctx.ctx 0. 0. ~r:1. ~a1:0. ~a2:(2. *. Float.pi);
 

--- a/lib/shape.ml
+++ b/lib/shape.ml
@@ -13,6 +13,7 @@ type ellipse = {
   c : float point;
   rx : float;
   ry : float;
+  rotation : float;
   stroke : color option;
   fill : color option;
 }
@@ -55,7 +56,7 @@ let rectangle ?(c = center) width height =
 
 let ellipse ?(c = center) rx ry =
   let rx, ry = (float_of_int rx, float_of_int ry) in
-  Ellipse { c; rx; ry; stroke = Some Color.black; fill = None }
+  Ellipse { c; rx; ry; stroke = Some Color.black; fill = None; rotation = 0. }
 
 let line ?(a = center) b = Line { a; b; stroke = Color.black }
 

--- a/lib/shape.mli
+++ b/lib/shape.mli
@@ -12,6 +12,7 @@ type ellipse = {
   c : float point;
   rx : float;
   ry : float;
+  rotation : float;
   stroke : color option;
   fill : color option;
 }

--- a/lib/transform.ml
+++ b/lib/transform.ml
@@ -82,7 +82,12 @@ let rotate_point degrees point =
 let rec rotate degrees = function
   | Circle circle' -> Circle { circle' with c = rotate_point degrees circle'.c }
   | Ellipse ellipse' ->
-      Ellipse { ellipse' with c = rotate_point degrees ellipse'.c }
+      Ellipse
+        {
+          ellipse' with
+          c = rotate_point degrees ellipse'.c;
+          rotation = ellipse'.rotation +. to_radians degrees;
+        }
   | Line line' -> Line { line' with a = rotate_point degrees line'.a; b = rotate_point degrees line'.b }
   | Polygon polygon' ->
       Polygon

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -36,3 +36,4 @@ let rec partition n ?(step = 0) lst =
 
 (* Misc *)
 let range n = List.init n Fun.id
+let to_radians degrees = degrees *. Stdlib.Float.pi /. 180.

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -10,3 +10,4 @@ val ( >> ) : ('a -> 'b) -> ('b -> 'c) -> 'a -> 'c
 val take : int -> 'a list -> 'a list * 'a list
 val partition : int -> ?step:int -> 'a list -> 'a list list
 val range : int -> int list
+val to_radians : float -> float


### PR DESCRIPTION
Previously, we only rotated the center of the ellipse, similar to the circle.
This commit adds a rotation field to the ellipse shape type which stores the
rotation of the ellipse in radians. And we use Cairo's rotate function when
rendering the ellipse.

Fixes #116 (in combination with #121, which has been merged) 

This PR also adds an example for ellipse rotation. 

![rotate_ellipse](https://github.com/Sudha247/ocaml-joy/assets/315678/f4cd7978-0071-4a60-b51a-325f03b53970)


The rectangle at the top right corner has been added to show that these rotations don't affect anything that's already been rendered.