### PR TITLE
Store ellipse rotation as degrees

### DIFF
--- a/lib/render.ml
+++ b/lib/render.ml
@@ -30,8 +30,9 @@ let draw_ellipse ctx { c; rx; ry; stroke; fill; rotation } =
   let save_matrix = Cairo.get_matrix ctx.ctx in
 
   (* Translate and scale to create an ellipse from a circle *)
+  let radians = to_radians rotation in
   Cairo.translate ctx.ctx c.x (Float.neg c.y);
-  Cairo.rotate ctx.ctx rotation;
+  Cairo.rotate ctx.ctx radians;
   Cairo.scale ctx.ctx rx ry;
   Cairo.arc ctx.ctx 0. 0. ~r:1. ~a1:0. ~a2:(2. *. Float.pi);
 

--- a/lib/shape.ml
+++ b/lib/shape.ml
@@ -13,7 +13,7 @@ type ellipse = {
   c : float point;
   rx : float;
   ry : float;
-  rotation : float;
+  rotation : int;
   stroke : color option;
   fill : color option;
 }
@@ -56,7 +56,7 @@ let rectangle ?(c = center) width height =
 
 let ellipse ?(c = center) rx ry =
   let rx, ry = (float_of_int rx, float_of_int ry) in
-  Ellipse { c; rx; ry; stroke = Some Color.black; fill = None; rotation = 0. }
+  Ellipse { c; rx; ry; stroke = Some Color.black; fill = None; rotation = 0 }
 
 let line ?(a = center) b = Line { a; b; stroke = Color.black }
 

--- a/lib/shape.mli
+++ b/lib/shape.mli
@@ -12,7 +12,7 @@ type ellipse = {
   c : float point;
   rx : float;
   ry : float;
-  rotation : float;
+  rotation : int;
   stroke : color option;
   fill : color option;
 }

--- a/lib/transform.ml
+++ b/lib/transform.ml
@@ -1,4 +1,5 @@
 open Shape
+open Util
 
 type transformation = shape -> shape
 
@@ -64,8 +65,6 @@ let rec scale factor = function
         }
   | Complex shapes -> Complex (List.map (scale factor) shapes)
 
-let to_radians degrees = float_of_int degrees *. Stdlib.Float.pi /. 180.
-
 let to_polar point =
   let { x; y } = point in
   (sqrt ((x *. x) +. (y *. y)), atan2 y x)
@@ -86,7 +85,7 @@ let rec rotate degrees = function
         {
           ellipse' with
           c = rotate_point degrees ellipse'.c;
-          rotation = ellipse'.rotation +. to_radians degrees;
+          rotation = ellipse'.rotation +  degrees;
         }
   | Line line' -> Line { line' with a = rotate_point degrees line'.a; b = rotate_point degrees line'.b }
   | Polygon polygon' ->

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -36,4 +36,4 @@ let rec partition n ?(step = 0) lst =
 
 (* Misc *)
 let range n = List.init n Fun.id
-let to_radians degrees = degrees *. Stdlib.Float.pi /. 180.
+let to_radians degrees = (float_of_int degrees) *. Stdlib.Float.pi /. 180.

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -10,4 +10,4 @@ val ( >> ) : ('a -> 'b) -> ('b -> 'c) -> 'a -> 'c
 val take : int -> 'a list -> 'a list * 'a list
 val partition : int -> ?step:int -> 'a list -> 'a list list
 val range : int -> int list
-val to_radians : float -> float
+val to_radians : int -> float


### PR DESCRIPTION
Stores ellipse rotation as degrees rather than radians. This is to ensure portability between backends, since radians is something specifc to the Cairo backend